### PR TITLE
Send timestamp into the signing script from apache

### DIFF
--- a/custom-apache-site.conf
+++ b/custom-apache-site.conf
@@ -42,6 +42,7 @@
 
         # AWS sigv4
         RewriteMap sigv4 prg:/opt/apache/sigv4-loop.sh
+        # This sends the timestamp and the request uri as a single string to the sigv4 script, concatenated with a '&'.
         RewriteRule (.*) - [E=sigv4Auth:${sigv4:%{ENV:timestamp}&%{REQUEST_URI}},P]
         RequestHeader set Authorization %{sigv4Auth}e
         RequestHeader set X-Amz-Security-Token %{AWS_SECURITY_TOKEN}e

--- a/custom-apache-site.conf
+++ b/custom-apache-site.conf
@@ -37,9 +37,12 @@
         PassEnv OBJECT_LAMBDA_HOST
         PassEnv AWS_SECURITY_TOKEN
 
+        # Set a timestamp of the format yyyy-MM-dd'T'HH:mm:ss'Z' for use in the sigv4 signing, and for the X-Amz-Date header
+        RewriteRule (.*) - [E=timestamp:%{TIME_YEAR}%{TIME_MON}%{TIME_DAY}T%{TIME_HOUR}%{TIME_MIN}%{TIME_SEC}Z]
+
         # AWS sigv4
         RewriteMap sigv4 prg:/opt/apache/sigv4-loop.sh
-        RewriteRule (.*) - [E=sigv4Auth:${sigv4:%{REQUEST_URI}},P]
+        RewriteRule (.*) - [E=sigv4Auth:${sigv4:%{ENV:timestamp}&%{REQUEST_URI}},P]
         RequestHeader set Authorization %{sigv4Auth}e
         RequestHeader set X-Amz-Security-Token %{AWS_SECURITY_TOKEN}e
 
@@ -48,7 +51,7 @@
         # Set a timestamp of the format yyyy-MM-dd'T'HH:mm:ss'Z'
         # Doing do here is a little awkward because the bash script will generate a timestamp too and they have to match.
         # Also this will need to be GMT time, not local time.
-        RequestHeader set X-Amz-Date expr=%{TIME_YEAR}%{TIME_MON}%{TIME_DAY}T%{TIME_HOUR}%{TIME_MIN}%{TIME_SEC}Z
+        RequestHeader set X-Amz-Date %{timestamp}e
 
         # https://stackoverflow.com/questions/19669465/how-to-use-environment-variable-from-mod-rewrite-for-interpolate-proxypass-in-ht
         ProxyPass / https://${OBJECT_LAMBDA_HOST}/ interpolate

--- a/header-script/sigv4-loop.sh
+++ b/header-script/sigv4-loop.sh
@@ -103,12 +103,14 @@ getAuthHeader() {
 setGlobals
 
 # This is the main loop.  It reads the URI from stdin and outputs the corresponding signed auth header to stdout.
+# The input consists of the timestamp and the request uri delimited by a '&'.  The timestamp comes first because it is a simpler alpha-numeric string.
 while read inputString
 do
 
   # Parse the input string into the timestamp and URI
-  string2=${inputString#*&}
-  string1=${inputString%"&$string2"}
+  string2=${inputString#*&} # the URI
+  string1=${inputString%"&$string2"} # the timestamp
+
   # Calculate the date and time stamps
   TIME_STAMP=${string1}
   DATE_STAMP="${TIME_STAMP:0:8}"

--- a/header-script/sigv4-loop.sh
+++ b/header-script/sigv4-loop.sh
@@ -103,12 +103,17 @@ getAuthHeader() {
 setGlobals
 
 # This is the main loop.  It reads the URI from stdin and outputs the corresponding signed auth header to stdout.
-while read inputUri
+while read inputString
 do
 
+  # Parse the input string into the timestamp and URI
+  string2=${inputString#*&}
+  string1=${inputString%"&$string2"}
   # Calculate the date and time stamps
-  TIME_STAMP="$(date --utc +'%Y%m%dT%H%M%SZ')"
+  TIME_STAMP=${string1}
   DATE_STAMP="${TIME_STAMP:0:8}"
+
+  inputUri=${string2}
 
   # Parameterized functions to calculate the signature
   thisCanonicalRequest=$(getCanonicalRequest "${inputUri}" "${TIME_STAMP}")


### PR DESCRIPTION
This way the timestamp in the signature is guaranteed to match the timestamp that apache adds as a standalone header.